### PR TITLE
Add timeouts to Brivo API calls

### DIFF
--- a/lib/brivo/api/http.rb
+++ b/lib/brivo/api/http.rb
@@ -6,13 +6,19 @@ module Brivo
       MAX_RETRIES = 3
       API_URL = -'https://api.brivo.com/v1/api'
       PAGE_SIZE = 100
+      DEFAULT_HTTPS_SETTINGS = {
+        use_ssl: true,
+        open_timeout: 3,
+        read_timeout: 3,
+        ssl_timeout: 3
+      }
 
       def set_access_token
         uri = URI.parse("https://auth.brivo.com/oauth/token?grant_type=password&username=#{username}&password=#{password}")
 
         authorization_code = Base64.strict_encode64("#{client_id}:#{secret}")
 
-        res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |https|
+        res = Net::HTTP.start(uri.host, uri.port, DEFAULT_HTTPS_SETTINGS) do |https|
           req = Net::HTTP::Post.new(uri)
           req['Content-Type'] = 'application/json'
           req['Authorization'] = "Basic #{authorization_code}"
@@ -50,7 +56,7 @@ module Brivo
             delete: Net::HTTP::Delete
           }
 
-          response = Net::HTTP.start(parsed_uri.host, parsed_uri.port, use_ssl: true) do |https|
+          response = Net::HTTP.start(parsed_uri.host, parsed_uri.port, DEFAULT_HTTPS_SETTINGS) do |https|
             request = http_methods[method].new(parsed_uri)
             request.body = params.to_json
 


### PR DESCRIPTION
This commit adds timeouts to the Brivo API calls. They are
quite aggressive intentionally, as this may be used
synchronously.

* Add `DEFAULT_HTTPS_SETTINGS` constant to `Brivo::API::HTTP`
* Use `DEFAULT_HTTPS_SETTINGS` when setting up `Net::HTTP`
  connections

Fixes #6